### PR TITLE
subscription SC min deposit value update

### DIFF
--- a/subscription-fee/src/common_storage.rs
+++ b/subscription-fee/src/common_storage.rs
@@ -23,9 +23,9 @@ pub trait CommonStorageModule {
         user_id: AddressId,
     ) -> SingleValueMapper<UniquePayments<Self::Api>>;
 
-    #[view(getMinTokenDepositValue)]
-    #[storage_mapper("minTokenDepositValue")]
-    fn min_token_deposit_value(&self, token_id: &TokenIdentifier) -> SingleValueMapper<BigUint>;
+    #[view(getMinStableTokenDepositValue)]
+    #[storage_mapper("minStableTokenDepositValue")]
+    fn min_stable_token_deposit_value(&self) -> SingleValueMapper<BigUint>;
 
     #[storage_mapper("userNextPaymentEpoch")]
     fn user_next_payment_epoch(

--- a/subscription-fee/src/fees.rs
+++ b/subscription-fee/src/fees.rs
@@ -22,12 +22,12 @@ pub trait FeesModule:
 
     #[only_owner]
     #[endpoint(setMinDepositValue)]
-    fn set_min_deposit_value(&self, token_id: TokenIdentifier, min_token_deposit_value: BigUint) {
-        if min_token_deposit_value == BigUint::zero() {
-            self.min_token_deposit_value(&token_id).clear();
+    fn set_min_deposit_value(&self, min_stable_token_deposit_value: BigUint) {
+        if min_stable_token_deposit_value == BigUint::zero() {
+            self.min_stable_token_deposit_value().clear();
         } else {
-            self.min_token_deposit_value(&token_id)
-                .set(min_token_deposit_value);
+            self.min_stable_token_deposit_value()
+                .set(min_stable_token_deposit_value);
         }
     }
 
@@ -48,11 +48,9 @@ pub trait FeesModule:
         require!(payment_value_result.is_ok(), "Could not get payment value");
 
         let payment_value = unsafe { payment_value_result.unwrap_unchecked() };
-        let min_token_deposit_value = self
-            .min_token_deposit_value(&payment.token_identifier)
-            .get();
+        let min_stable_token_deposit_value = self.min_stable_token_deposit_value().get();
         require!(
-            payment_value >= min_token_deposit_value,
+            payment_value >= min_stable_token_deposit_value,
             "Payment value is lesser than the minimum accepted"
         );
 

--- a/subscription-fee/tests/subscription_setup/mod.rs
+++ b/subscription-fee/tests/subscription_setup/mod.rs
@@ -14,7 +14,7 @@ use subscription_fee::{
     SubscriptionFee,
 };
 
-use crate::{FIRST_TOKEN_ID, USDC_TOKEN_ID, WEGLD_TOKEN_ID};
+use crate::{USDC_TOKEN_ID, WEGLD_TOKEN_ID};
 
 pub const MIN_USER_DEPOSIT_VALUE: u64 = 1_000_000;
 
@@ -63,10 +63,7 @@ where
                     args,
                 );
 
-                sc.set_min_deposit_value(
-                    managed_token_id!(FIRST_TOKEN_ID),
-                    managed_biguint!(MIN_USER_DEPOSIT_VALUE),
-                );
+                sc.set_min_deposit_value(managed_biguint!(MIN_USER_DEPOSIT_VALUE));
             })
             .assert_ok();
 

--- a/subscription-fee/wasm/src/lib.rs
+++ b/subscription-fee/wasm/src/lib.rs
@@ -28,7 +28,7 @@ multiversx_sc_wasm_adapter::endpoints! {
         withdrawFunds => withdraw_funds
         getAcceptedFeesTokens => accepted_fees_tokens
         getUserDepositedFees => user_deposited_fees
-        getMinTokenDepositValue => min_token_deposit_value
+        getMinStableTokenDepositValue => min_stable_token_deposit_value
         getPendingServices => pending_services
         getServiceInfo => service_info
         getSubscribedUsers => subscribed_users


### PR DESCRIPTION
Updated the min deposit value storage to be generic (no storage key), as we always convert the payment to the stable token value beforehand.